### PR TITLE
Fixes a bug where the min and max were not included in the check

### DIFF
--- a/XkPassword.Demo/MainWindow.xaml
+++ b/XkPassword.Demo/MainWindow.xaml
@@ -93,6 +93,7 @@
                         <ComboBoxItem>iNVERTED cASE</ComboBoxItem>
                         <ComboBoxItem>AlTeRnAtInG CaSe</ComboBoxItem>
                         <ComboBoxItem>rANdoMly CAPitaLiZE</ComboBoxItem>
+                        <ComboBoxItem>RANDOMLY capitalize entire WORD</ComboBoxItem>
                     </ComboBox.Items>
                 </ComboBox>
             </DockPanel>

--- a/XkPassword/CaseTransformation.cs
+++ b/XkPassword/CaseTransformation.cs
@@ -38,6 +38,11 @@
         /// <summary>
         ///     RAndOmLY capITAliZe thE WorD.
         /// </summary>
-        Random = 6
+        Random = 6,
+
+        /// <summary>
+        ///     RANDOMLY capitalize entire WORD
+        /// </summary>
+        RandomWord = 7
     }
 }

--- a/XkPassword/XkPasswd.cs
+++ b/XkPassword/XkPasswd.cs
@@ -336,7 +336,7 @@ namespace XkPassword
 
             IEnumerable<string> suitableWords =
                 reader.ReadAllLines()
-                      .Where(w => (w.Length > this.MinWordLength) && (w.Length < this.MaxWordLength))
+                      .Where(w => (w.Length >= this.MinWordLength) && (w.Length <= this.MaxWordLength))
                       .ToList();
 
 #if DEBUG

--- a/XkPassword/XkPasswd.cs
+++ b/XkPassword/XkPasswd.cs
@@ -402,6 +402,8 @@ namespace XkPassword
                                      new string(
                                          w.ToUpperInvariant().Select(c => (char)(c + (this.RandomSource.CoinFlip() ? ' ' : '\0')))
                                           .ToArray()));
+                case CaseTransformation.RandomWord:
+                    return words.Select(w => this.RandomSource.CoinFlip() ? w.ToUpperInvariant() : w.ToLowerInvariant());
                 default:
                     return words;
             }


### PR DESCRIPTION
I was trying to have a password that had 3 words each 4 characters long. The min and max was not inclusive so it was saying a word that is less than 4 and greater than 4. That was causing an error.

Also adds a feature that was in the perl script which randomly capitalizes an entire word.
